### PR TITLE
fix: article form 유효성 검증 로직 추가

### DIFF
--- a/lib/api/article.ts
+++ b/lib/api/article.ts
@@ -65,21 +65,31 @@ const ArticleAPI = {
   },
 
   create: async (article, token) => {
-    const { data, status } = await axios.post(
-      `${SERVER_BASE_URL}/articles`,
-      JSON.stringify({ article }),
-      {
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Token ${encodeURIComponent(token)}`,
-        },
+    try {
+      const { data, status } = await axios.post(
+        `${SERVER_BASE_URL}/articles`,
+        JSON.stringify({ article }),
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Token ${encodeURIComponent(token)}`,
+          },
+        }
+      );
+      return {
+        data,
+        status,
+      };
+    } catch (error) {
+      if (error.response) {
+        console.log("400 에러:", error.response.data);
+      } else {
+        console.log("기타 에러:", error.message);
       }
-    );
-    return {
-      data,
-      status,
-    };
+      throw error;
+    }
   },
+
 };
 
 export default ArticleAPI;

--- a/lib/utils/validateArticle.ts
+++ b/lib/utils/validateArticle.ts
@@ -1,0 +1,30 @@
+export interface ArticleFields {
+  title: string;
+  description: string;
+  body: string;
+}
+
+function validateArticle(article: ArticleFields): string | null {
+  const missingFields: string[] = [];
+
+  const title = article.title.trim();
+  const description = article.description.trim();
+  const body = article.body.trim();
+
+  if (!title) {
+    missingFields.push("제목")
+  }
+  if (!description) {
+    missingFields.push("설명")
+  }
+  if (!body) {
+    missingFields.push("본문")
+  }
+  if (missingFields.length > 0) {
+    return `${missingFields.join(", ")}을(를) 입력해주세요.`;
+  }
+
+  return null;
+}
+
+export default validateArticle;

--- a/pages/editor/[pid].tsx
+++ b/pages/editor/[pid].tsx
@@ -9,6 +9,7 @@ import ArticleAPI from "../../lib/api/article";
 import { SERVER_BASE_URL } from "../../lib/utils/constant";
 import editorReducer from "../../lib/utils/editorReducer";
 import storage from "../../lib/utils/storage";
+import validateArticle from "lib/utils/validateArticle";
 
 const UpdateArticleEditor = ({ article: initialArticle }) => {
   const initialState = {
@@ -39,25 +40,13 @@ const UpdateArticleEditor = ({ article: initialArticle }) => {
   const handleSubmit = async (e) => {
     e.preventDefault();
 
-        const missingFields = [];
+    const errorMessage = validateArticle(posting);
 
-    if (!posting.title.trim()) {
-      missingFields.push("제목");
-    }
-
-    if (!posting.description.trim()) {
-      missingFields.push("설명");
-    }
-
-    if (!posting.body.trim()) {
-      missingFields.push("본문");
-    }
-
-    if (missingFields.length > 0) {
-      alert(`${missingFields.join(", ")}을(를) 입력해주세요.`);
+    if (errorMessage) {
+      alert(errorMessage);
       return;
     }
-    
+
     setLoading(true);
 
     const { data, status } = await axios.put(

--- a/pages/editor/[pid].tsx
+++ b/pages/editor/[pid].tsx
@@ -38,6 +38,26 @@ const UpdateArticleEditor = ({ article: initialArticle }) => {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+
+        const missingFields = [];
+
+    if (!posting.title.trim()) {
+      missingFields.push("제목");
+    }
+
+    if (!posting.description.trim()) {
+      missingFields.push("설명");
+    }
+
+    if (!posting.body.trim()) {
+      missingFields.push("본문");
+    }
+
+    if (missingFields.length > 0) {
+      alert(`${missingFields.join(", ")}을(를) 입력해주세요.`);
+      return;
+    }
+    
     setLoading(true);
 
     const { data, status } = await axios.put(

--- a/pages/editor/new.tsx
+++ b/pages/editor/new.tsx
@@ -32,6 +32,26 @@ const PublishArticleEditor = () => {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+
+    const missingFields = [];
+
+    if (!posting.title.trim()) {
+      missingFields.push("제목");
+    }
+
+    if (!posting.description.trim()) {
+      missingFields.push("설명");
+    }
+
+    if (!posting.body.trim()) {
+      missingFields.push("본문");
+    }
+
+    if (missingFields.length > 0) {
+      alert(`${missingFields.join(", ")}을(를) 입력해주세요.`);
+      return;
+    }
+
     setLoading(true);
 
     const { data, status } = await ArticleAPI.create(

--- a/pages/editor/new.tsx
+++ b/pages/editor/new.tsx
@@ -7,6 +7,7 @@ import TagInput from "../../features/editor/TagInput";
 import ArticleAPI from "../../lib/api/article";
 import storage from "../../lib/utils/storage";
 import editorReducer from "../../lib/utils/editorReducer";
+import validateArticle from "lib/utils/validateArticle";
 
 const PublishArticleEditor = () => {
   const initialState = {
@@ -33,22 +34,10 @@ const PublishArticleEditor = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
 
-    const missingFields = [];
+    const errorMessage = validateArticle(posting);
 
-    if (!posting.title.trim()) {
-      missingFields.push("제목");
-    }
-
-    if (!posting.description.trim()) {
-      missingFields.push("설명");
-    }
-
-    if (!posting.body.trim()) {
-      missingFields.push("본문");
-    }
-
-    if (missingFields.length > 0) {
-      alert(`${missingFields.join(", ")}을(를) 입력해주세요.`);
+    if (errorMessage) {
+      alert(errorMessage);
       return;
     }
 

--- a/shared/components/ListErrors.tsx
+++ b/shared/components/ListErrors.tsx
@@ -1,15 +1,21 @@
 import React from "react";
 
-const ListErrors = ({ errors }) => (
-  <ul className="error-messages">
-    {Object.keys(errors).map((key) => {
-      return (
-        <li key={key}>
-          {key} {errors[key]}
-        </li>
-      );
-    })}
-  </ul>
-);
+const ListErrors = ({ errors }) => {
+  if (!errors || typeof errors !== "object"){
+    return null
+  }
+  else{
+    return (
+      <ul className="error-messages">
+        {Object.keys(errors).map((key) => (
+          <li key={key}>
+            {key} {errors[key]}
+          </li>
+        ))}
+      </ul>
+    );
+  }
+};
+
 
 export default ListErrors;


### PR DESCRIPTION
## #️⃣연관된 이슈

#3 

## 📝작업 내용

- article form에 누락 된 부분이 있는채로 article을 생성하거나 수정하면 400번 오류 발생

- article form의 유효성을 검사하는 로직은 create든, edit든 동일하기 때문에 validateArticle을 만들어 utils로 분리