### PR TITLE
fix: tablist your feed 부분 endpoint 변경

### DIFF
--- a/features/home/TabList.tsx
+++ b/features/home/TabList.tsx
@@ -44,8 +44,8 @@ const TabList = () => {
     <ul className="nav nav-pills outline-active">
       <li className="nav-item">
         <NavLink
-          href={`/?follow=${currentUser?.username}`}
-          as={`/?follow=${currentUser?.username}`}
+          href={`/?user=${currentUser?.username}`}
+          as={`/?user=${currentUser?.username}`}
         >
           Your Feed
         </NavLink>


### PR DESCRIPTION
## #️⃣연관된 이슈

#3 

## 📝작업 내용

- 유저 피드 엔드포인트 수정
    - 프론트에서 follow 파라미터를 user로 변경하여 백엔드 API 구조에 맞춤
- 게시글 엔드포인트 슬래시 처리
    -  `/articles`와 `/articles/` 두 경로 모두 지원하도록 백엔드에 라우트 추가
    ```python
     @router.get("/articles", response={200: Any})
     @router.get("/articles/", response={200: Any})
    ```