### PR TITLE
chore: slug encoding 처리

### DIFF
--- a/lib/api/article.ts
+++ b/lib/api/article.ts
@@ -1,85 +1,65 @@
 import axios from "axios";
-
 import { SERVER_BASE_URL } from "../utils/constant";
 import { getQuery } from "../utils/getQuery";
 
+const article = `${SERVER_BASE_URL}/articles`;
+const withSlug = (slug) => `${article}/${encodeURIComponent(slug)}`;
+const withToken = (token) => ({
+  headers: {
+    Authorization: `Token ${encodeURIComponent(token)}`,
+    "Content-Type": "application/json",
+  },
+});
+
 const ArticleAPI = {
   all: (page, limit = 10) =>
-    axios.get(`${SERVER_BASE_URL}/articles?${getQuery(limit, page)}`),
+    axios.get(`${article}?${getQuery(limit, page)}`),
 
   byAuthor: (author, page = 0, limit = 5) =>
-    axios.get(
-      `${SERVER_BASE_URL}/articles?author=${encodeURIComponent(
-        author
-      )}&${getQuery(limit, page)}`
-    ),
+    axios.get(`${article}?author=${encodeURIComponent(author)}&${getQuery(limit, page)}`),
 
   byTag: (tag, page = 0, limit = 10) =>
-    axios.get(
-      `${SERVER_BASE_URL}/articles?tag=${encodeURIComponent(tag)}&${getQuery(
-        limit,
-        page
-      )}`
-    ),
+    axios.get(`${article}?tag=${encodeURIComponent(tag)}&${getQuery(limit, page)}`),
 
-  delete: (id, token) =>
-    axios.delete(`${SERVER_BASE_URL}/articles/${id}`, {
+  delete: (slug, token) =>
+    axios.delete(withSlug(slug), {
       headers: {
-        Authorization: `Token ${token}`,
+        Authorization: `Token ${encodeURIComponent(token)}`,
       },
     }),
 
   favorite: (slug) =>
-    axios.post(`${SERVER_BASE_URL}/articles/${slug}/favorite`),
+    axios.post(`${withSlug(slug)}/favorite`),
 
   favoritedBy: (author, page) =>
-    axios.get(
-      `${SERVER_BASE_URL}/articles?favorited=${encodeURIComponent(
-        author
-      )}&${getQuery(10, page)}`
-    ),
+    axios.get(`${article}?favorited=${encodeURIComponent(author)}&${getQuery(10, page)}`),
 
   feed: (page, limit = 10) =>
-    axios.get(`${SERVER_BASE_URL}/articles/feed?${getQuery(limit, page)}`),
+    axios.get(`${article}/feed?${getQuery(limit, page)}`),
 
-  get: (slug) => axios.get(`${SERVER_BASE_URL}/articles/${slug}`),
+  get: (slug) =>
+    axios.get(withSlug(slug)),
 
   unfavorite: (slug) =>
-    axios.delete(`${SERVER_BASE_URL}/articles/${slug}/favorite`),
+    axios.delete(`${withSlug(slug)}/favorite`),
 
   update: async (article, token) => {
     const { data, status } = await axios.put(
-      `${SERVER_BASE_URL}/articles/${article.slug}`,
+      withSlug(article.slug),
       JSON.stringify({ article }),
-      {
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Token ${encodeURIComponent(token)}`,
-        },
-      }
+      withToken(token)
     );
-    return {
-      data,
-      status,
-    };
+    return { data, status };
   },
 
-  create: async (article, token) => {
+  create: async (articleData, token) => {
     try {
       const { data, status } = await axios.post(
-        `${SERVER_BASE_URL}/articles`,
-        JSON.stringify({ article }),
-        {
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Token ${encodeURIComponent(token)}`,
-          },
-        }
+        article,
+        JSON.stringify({ article: articleData }),
+        withToken(token)
       );
-      return {
-        data,
-        status,
-      };
+      return { data, status };
     } catch (error) {
       if (error.response) {
         console.log("400 에러:", error.response.data);
@@ -89,7 +69,6 @@ const ArticleAPI = {
       throw error;
     }
   },
-
-};
+}
 
 export default ArticleAPI;


### PR DESCRIPTION
## #️⃣연관된 이슈

#6 

## 📝작업 내용

- frontend (`lib/api/article` 수정)
    - [encodeURIComponent](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent)로 slug를 감싸줬습니다.
    - 반복되는 코드가 많아 상위에 변수로 따로 빼서 사용했습니다.

- backend (`app/articles/models` 수정)
    - python-slugify 플러그인 설치 후 인코딩 처리