### PR TITLE
refactor: pages/editor 리팩토링

### DIFF
--- a/features/editor/EditorForm.tsx
+++ b/features/editor/EditorForm.tsx
@@ -1,0 +1,94 @@
+import { FormEvent, useReducer } from 'react';
+import ListErrors from '../../shared/components/ListErrors';
+import TagInput from './TagInput';
+import editorReducer from '../../lib/utils/editorReducer';
+import validateArticle from '../../lib/utils/validateArticle';
+
+import TextInput from '../../shared/ui/input/TextInput';
+import TextArea from '../../shared/ui/input/TextArea';
+import SubmitButton from '../../shared/ui/button/SubmitButton';
+
+export interface ArticleInput {
+  title: string;
+  description: string;
+  body: string;
+  tagList: string[];
+}
+
+interface EditorFormProps {
+  initialValues: ArticleInput;
+  isLoading: boolean;
+  errors: any[];
+  onSubmit: (data: ArticleInput) => void;
+  submitLabel: string;
+}
+
+const EditorForm = ({
+  initialValues,
+  isLoading,
+  errors,
+  onSubmit,
+  submitLabel,
+}: EditorFormProps) => {
+  const [posting, dispatch] = useReducer(editorReducer, initialValues);
+
+  const handleChange = (type: string) => (e: any) =>
+    dispatch({ type, text: e.target.value });
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const error = validateArticle(posting);
+    if (error) {
+      alert(error);
+      return;
+    }
+    onSubmit(posting);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <ListErrors errors={errors} />
+
+      <fieldset>
+        <fieldset className="form-group">
+          <TextInput
+            placeholder="Article Title"
+            value={posting.title}
+            onChange={handleChange('SET_TITLE')}
+            className="form-control-lg"
+          />
+        </fieldset>
+
+        <fieldset className="form-group">
+          <TextInput
+            placeholder="What's this article about?"
+            value={posting.description}
+            onChange={handleChange('SET_DESCRIPTION')}
+          />
+        </fieldset>
+
+        <fieldset className="form-group">
+          <TextArea
+            placeholder="Write your article (in markdown)"
+            value={posting.body}
+            onChange={handleChange('SET_BODY')}
+          />
+        </fieldset>
+
+        <TagInput
+          tagList={posting.tagList}
+          addTag={(tag) => dispatch({ type: 'ADD_TAG', tag })}
+          removeTag={(tag) => dispatch({ type: 'REMOVE_TAG', tag })}
+        />
+
+        <SubmitButton
+          label={submitLabel}
+          isLoading={isLoading}
+          onClick={() => onSubmit(posting)}
+        />
+      </fieldset>
+    </form>
+  );
+};
+
+export default EditorForm;

--- a/pages/editor/[pid].tsx
+++ b/pages/editor/[pid].tsx
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import Router, { useRouter } from 'next/router';
-import React from 'react';
+import { useState, useReducer } from 'react';
 import useSWR from 'swr';
 
 import ListErrors from '../../shared/components/ListErrors';
@@ -19,9 +19,9 @@ const UpdateArticleEditor = ({ article: initialArticle }) => {
     tagList: initialArticle.tagList,
   };
 
-  const [isLoading, setLoading] = React.useState(false);
-  const [errors, setErrors] = React.useState([]);
-  const [posting, dispatch] = React.useReducer(editorReducer, initialState);
+  const [isLoading, setLoading] = useState(false);
+  const [errors, setErrors] = useState([]);
+  const [posting, dispatch] = useReducer(editorReducer, initialState);
   const { data: currentUser } = useSWR('user', storage);
   const router = useRouter();
   const {

--- a/pages/editor/[slug].tsx
+++ b/pages/editor/[slug].tsx
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import Router, { useRouter } from 'next/router';
-import { useState, useReducer, ChangeEvent } from 'react';
+import { useState, useReducer, ChangeEvent, FormEvent } from 'react';
 import useSWR from 'swr';
 
 import ListErrors from '../../shared/components/ListErrors';
@@ -41,7 +41,7 @@ const UpdateArticleEditor = ({ article: initialArticle }) => {
   const addTag = (tag: string) => dispatch({ type: 'ADD_TAG', tag: tag });
   const removeTag = (tag: string) => dispatch({ type: 'REMOVE_TAG', tag: tag });
 
-  const handleSubmit = async (e) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
 
     const errorMessage = validateArticle(posting);

--- a/pages/editor/[slug].tsx
+++ b/pages/editor/[slug].tsx
@@ -38,8 +38,8 @@ const UpdateArticleEditor = ({ article: initialArticle }) => {
   const handleBody = (e: TextareaChange) =>
     dispatch({ type: 'SET_BODY', text: e.target.value });
 
-  const addTag = (tag) => dispatch({ type: 'ADD_TAG', tag: tag });
-  const removeTag = (tag) => dispatch({ type: 'REMOVE_TAG', tag: tag });
+  const addTag = (tag: string) => dispatch({ type: 'ADD_TAG', tag: tag });
+  const removeTag = (tag: string) => dispatch({ type: 'REMOVE_TAG', tag: tag });
 
   const handleSubmit = async (e) => {
     e.preventDefault();

--- a/pages/editor/[slug].tsx
+++ b/pages/editor/[slug].tsx
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import Router, { useRouter } from 'next/router';
 import { useState, useReducer, ChangeEvent, FormEvent } from 'react';
 import useSWR from 'swr';
@@ -6,7 +5,6 @@ import useSWR from 'swr';
 import ListErrors from '../../shared/components/ListErrors';
 import TagInput from '../../features/editor/TagInput';
 import ArticleAPI from '../../lib/api/article';
-import { SERVER_BASE_URL } from '../../lib/utils/constant';
 import editorReducer from '../../lib/utils/editorReducer';
 import storage from '../../lib/utils/storage';
 import validateArticle from 'lib/utils/validateArticle';
@@ -53,16 +51,11 @@ const UpdateArticleEditor = ({ article: initialArticle }) => {
 
     setLoading(true);
 
-    const { data, status } = await axios.put(
-      `${SERVER_BASE_URL}/articles/${slug}`,
-      JSON.stringify({ article: posting }),
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Token ${encodeURIComponent(currentUser?.token)}`,
-        },
-      },
+    const { data, status } = await ArticleAPI.update(
+      { ...posting, slug },
+      currentUser?.token,
     );
+
     setLoading(false);
 
     if (status !== 200) {

--- a/pages/editor/[slug].tsx
+++ b/pages/editor/[slug].tsx
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import Router, { useRouter } from 'next/router';
-import { useState, useReducer } from 'react';
+import { useState, useReducer, ChangeEvent } from 'react';
 import useSWR from 'swr';
 
 import ListErrors from '../../shared/components/ListErrors';
@@ -28,12 +28,16 @@ const UpdateArticleEditor = ({ article: initialArticle }) => {
     query: { slug },
   } = router;
 
-  const handleTitle = (e) =>
+  type InputChange = ChangeEvent<HTMLInputElement>;
+  type TextareaChange = ChangeEvent<HTMLTextAreaElement>;
+
+  const handleTitle = (e: InputChange) =>
     dispatch({ type: 'SET_TITLE', text: e.target.value });
-  const handleDescription = (e) =>
+  const handleDescription = (e: InputChange) =>
     dispatch({ type: 'SET_DESCRIPTION', text: e.target.value });
-  const handleBody = (e) =>
+  const handleBody = (e: TextareaChange) =>
     dispatch({ type: 'SET_BODY', text: e.target.value });
+
   const addTag = (tag) => dispatch({ type: 'ADD_TAG', tag: tag });
   const removeTag = (tag) => dispatch({ type: 'REMOVE_TAG', tag: tag });
 

--- a/pages/editor/[slug].tsx
+++ b/pages/editor/[slug].tsx
@@ -25,7 +25,7 @@ const UpdateArticleEditor = ({ article: initialArticle }) => {
   const { data: currentUser } = useSWR('user', storage);
   const router = useRouter();
   const {
-    query: { pid },
+    query: { slug },
   } = router;
 
   const handleTitle = (e) =>
@@ -50,7 +50,7 @@ const UpdateArticleEditor = ({ article: initialArticle }) => {
     setLoading(true);
 
     const { data, status } = await axios.put(
-      `${SERVER_BASE_URL}/articles/${pid}`,
+      `${SERVER_BASE_URL}/articles/${slug}`,
       JSON.stringify({ article: posting }),
       {
         headers: {
@@ -130,10 +130,10 @@ const UpdateArticleEditor = ({ article: initialArticle }) => {
   );
 };
 
-UpdateArticleEditor.getInitialProps = async ({ query: { pid } }) => {
+UpdateArticleEditor.getInitialProps = async ({ query: { slug } }) => {
   const {
     data: { article },
-  } = await ArticleAPI.get(pid);
+  } = await ArticleAPI.get(slug);
   return { article };
 };
 

--- a/pages/editor/new.tsx
+++ b/pages/editor/new.tsx
@@ -32,8 +32,8 @@ const PublishArticleEditor = () => {
   const handleBody = (e: TextareaChange) =>
     dispatch({ type: 'SET_BODY', text: e.target.value });
 
-  const addTag = (tag) => dispatch({ type: 'ADD_TAG', tag: tag });
-  const removeTag = (tag) => dispatch({ type: 'REMOVE_TAG', tag: tag });
+  const addTag = (tag: string) => dispatch({ type: 'ADD_TAG', tag: tag });
+  const removeTag = (tag: string) => dispatch({ type: 'REMOVE_TAG', tag: tag });
 
   const handleSubmit = async (e) => {
     e.preventDefault();

--- a/pages/editor/new.tsx
+++ b/pages/editor/new.tsx
@@ -1,5 +1,5 @@
 import Router from 'next/router';
-import { ChangeEvent, useReducer, useState } from 'react';
+import { ChangeEvent, FormEvent, useReducer, useState } from 'react';
 import useSWR from 'swr';
 
 import ListErrors from '../../shared/components/ListErrors';
@@ -35,7 +35,7 @@ const PublishArticleEditor = () => {
   const addTag = (tag: string) => dispatch({ type: 'ADD_TAG', tag: tag });
   const removeTag = (tag: string) => dispatch({ type: 'REMOVE_TAG', tag: tag });
 
-  const handleSubmit = async (e) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
 
     const errorMessage = validateArticle(posting);

--- a/pages/editor/new.tsx
+++ b/pages/editor/new.tsx
@@ -1,5 +1,5 @@
 import Router from 'next/router';
-import React from 'react';
+import { useReducer, useState } from 'react';
 import useSWR from 'swr';
 
 import ListErrors from '../../shared/components/ListErrors';
@@ -17,9 +17,9 @@ const PublishArticleEditor = () => {
     tagList: [],
   };
 
-  const [isLoading, setLoading] = React.useState(false);
-  const [errors, setErrors] = React.useState([]);
-  const [posting, dispatch] = React.useReducer(editorReducer, initialState);
+  const [isLoading, setLoading] = useState(false);
+  const [errors, setErrors] = useState([]);
+  const [posting, dispatch] = useReducer(editorReducer, initialState);
   const { data: currentUser } = useSWR('user', storage);
 
   const handleTitle = (e) =>

--- a/pages/editor/new.tsx
+++ b/pages/editor/new.tsx
@@ -1,5 +1,5 @@
 import Router from 'next/router';
-import { useReducer, useState } from 'react';
+import { ChangeEvent, useReducer, useState } from 'react';
 import useSWR from 'swr';
 
 import ListErrors from '../../shared/components/ListErrors';
@@ -22,12 +22,16 @@ const PublishArticleEditor = () => {
   const [posting, dispatch] = useReducer(editorReducer, initialState);
   const { data: currentUser } = useSWR('user', storage);
 
-  const handleTitle = (e) =>
+  type InputChange = ChangeEvent<HTMLInputElement>;
+  type TextareaChange = ChangeEvent<HTMLTextAreaElement>;
+
+  const handleTitle = (e: InputChange) =>
     dispatch({ type: 'SET_TITLE', text: e.target.value });
-  const handleDescription = (e) =>
+  const handleDescription = (e: InputChange) =>
     dispatch({ type: 'SET_DESCRIPTION', text: e.target.value });
-  const handleBody = (e) =>
+  const handleBody = (e: TextareaChange) =>
     dispatch({ type: 'SET_BODY', text: e.target.value });
+
   const addTag = (tag) => dispatch({ type: 'ADD_TAG', tag: tag });
   const removeTag = (tag) => dispatch({ type: 'REMOVE_TAG', tag: tag });
 

--- a/pages/editor/new.tsx
+++ b/pages/editor/new.tsx
@@ -1,125 +1,51 @@
-import Router from 'next/router';
-import { ChangeEvent, FormEvent, useReducer, useState } from 'react';
+import { useState } from 'react';
 import useSWR from 'swr';
+import Router from 'next/router';
 
-import ListErrors from '../../shared/components/ListErrors';
-import TagInput from '../../features/editor/TagInput';
-import ArticleAPI from '../../lib/api/article';
 import storage from '../../lib/utils/storage';
-import editorReducer from '../../lib/utils/editorReducer';
-import validateArticle from 'lib/utils/validateArticle';
+import ArticleAPI from '../../lib/api/article';
+import EditorForm, { ArticleInput } from '../../features/editor/EditorForm';
 
-const PublishArticleEditor = () => {
-  const initialState = {
-    title: '',
-    description: '',
-    body: '',
-    tagList: [],
-  };
-
-  const [isLoading, setLoading] = useState(false);
+const NewArticlePage = () => {
   const [errors, setErrors] = useState([]);
-  const [posting, dispatch] = useReducer(editorReducer, initialState);
+  const [isLoading, setLoading] = useState(false);
   const { data: currentUser } = useSWR('user', storage);
 
-  type InputChange = ChangeEvent<HTMLInputElement>;
-  type TextareaChange = ChangeEvent<HTMLTextAreaElement>;
-
-  const handleTitle = (e: InputChange) =>
-    dispatch({ type: 'SET_TITLE', text: e.target.value });
-  const handleDescription = (e: InputChange) =>
-    dispatch({ type: 'SET_DESCRIPTION', text: e.target.value });
-  const handleBody = (e: TextareaChange) =>
-    dispatch({ type: 'SET_BODY', text: e.target.value });
-
-  const addTag = (tag: string) => dispatch({ type: 'ADD_TAG', tag: tag });
-  const removeTag = (tag: string) => dispatch({ type: 'REMOVE_TAG', tag: tag });
-
-  const handleSubmit = async (e: FormEvent) => {
-    e.preventDefault();
-
-    const errorMessage = validateArticle(posting);
-
-    if (errorMessage) {
-      alert(errorMessage);
-      return;
-    }
-
+  const handleSubmit = async (data: ArticleInput) => {
     setLoading(true);
 
-    const { data, status } = await ArticleAPI.create(
-      posting,
+    const { data: res, status } = await ArticleAPI.create(
+      data,
       currentUser?.token,
     );
 
     setLoading(false);
 
-    if (status !== 200) {
-      setErrors(data.errors);
-    }
+    if (status !== 200) return setErrors(res.errors);
 
     Router.push('/');
   };
 
   return (
-    <div className="editor-page">
-      <div className="container page">
-        <div className="row">
-          <div className="col-md-10 offset-md-1 col-xs-12">
-            <ListErrors errors={errors} />
-            <form>
-              <fieldset>
-                <fieldset className="form-group">
-                  <input
-                    className="form-control form-control-lg"
-                    type="text"
-                    placeholder="Article Title"
-                    value={posting.title}
-                    onChange={handleTitle}
-                  />
-                </fieldset>
-
-                <fieldset className="form-group">
-                  <input
-                    className="form-control"
-                    type="text"
-                    placeholder="What's this article about?"
-                    value={posting.description}
-                    onChange={handleDescription}
-                  />
-                </fieldset>
-
-                <fieldset className="form-group">
-                  <textarea
-                    className="form-control"
-                    rows={8}
-                    placeholder="Write your article (in markdown)"
-                    value={posting.body}
-                    onChange={handleBody}
-                  />
-                </fieldset>
-
-                <TagInput
-                  tagList={posting.tagList}
-                  addTag={addTag}
-                  removeTag={removeTag}
-                />
-
-                <button
-                  className="btn btn-lg pull-xs-right btn-primary"
-                  type="button"
-                  disabled={isLoading}
-                  onClick={handleSubmit}
-                >
-                  Publish Article
-                </button>
-              </fieldset>
-            </form>
-          </div>
+    <div className="editor-page container page">
+      <div className="row">
+        <div className="col-md-10 offset-md-1 col-xs-12">
+          <EditorForm
+            initialValues={{
+              title: '',
+              description: '',
+              body: '',
+              tagList: [],
+            }}
+            isLoading={isLoading}
+            errors={errors}
+            onSubmit={handleSubmit}
+            submitLabel="Publish Article"
+          />
         </div>
       </div>
     </div>
   );
 };
 
-export default PublishArticleEditor;
+export default NewArticlePage;

--- a/shared/ui/button/SubmitButton.tsx
+++ b/shared/ui/button/SubmitButton.tsx
@@ -1,0 +1,18 @@
+interface SubmitButtonProps {
+  label: string;
+  isLoading: boolean;
+  onClick: () => void;
+}
+
+const SubmitButton = ({ label, isLoading, onClick }: SubmitButtonProps) => (
+  <button
+    type="button"
+    className="btn btn-lg pull-xs-right btn-primary"
+    disabled={isLoading}
+    onClick={onClick}
+  >
+    {label}
+  </button>
+);
+
+export default SubmitButton;

--- a/shared/ui/input/TextArea.tsx
+++ b/shared/ui/input/TextArea.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+interface TextAreaProps {
+  placeholder: string;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  rows?: number;
+  className?: string;
+}
+
+const TextArea = ({
+  placeholder,
+  value,
+  onChange,
+  rows = 8,
+  className = '',
+}: TextAreaProps) => (
+  <textarea
+    className={`form-control ${className}`}
+    rows={rows}
+    placeholder={placeholder}
+    value={value}
+    onChange={onChange}
+  />
+);
+
+export default TextArea;

--- a/shared/ui/input/TextInput.tsx
+++ b/shared/ui/input/TextInput.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface TextInputProps {
+  placeholder: string;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  className?: string;
+}
+
+const TextInput = ({
+  placeholder,
+  value,
+  onChange,
+  className = '',
+}: TextInputProps) => (
+  <input
+    type="text"
+    placeholder={placeholder}
+    className={`form-control ${className}`}
+    value={value}
+    onChange={onChange}
+  />
+);
+
+export default TextInput;


### PR DESCRIPTION
## #️⃣연관된 이슈

#9 

## 📝작업 내용

import 형식 named import로 변경

editor 페이지 pid -> slug로 변경


editor 이벤트 객체 타입 정의

tag 타입 정의

submit 함수 이벤트 객체 타입 정의

Article api에서 put

article에서 사용하는 input 컴포넌트 분리

article에서 사용하는 text area 컴포넌트 분리

submit button 컴포넌트 분리

editorForm에서 공통 로직 관리