### PR TITLE
refactor: 404 에러 및 데이터 페칭 오류 처리

### DIFF
--- a/features/article/ArticlePreview.tsx
+++ b/features/article/ArticlePreview.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import Router from 'next/router';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import useSWR from 'swr';
 
 import CustomLink from '../../shared/components/CustomLink';
@@ -25,10 +25,6 @@ const ArticlePreview = ({ article }: ArticleProps) => {
   const isLoggedIn = checkLogin(currentUser);
   const favoriteMutation = useFavoriteMutation();
 
-  // article prop이 변경될 때마다 preview 상태 업데이트
-  useEffect(() => {
-    setPreview(article);
-  }, [article]);
   const toggleFavorite = async () => {
     if (!isLoggedIn) {
       Router.push('/user/login');
@@ -67,14 +63,7 @@ const ArticlePreview = ({ article }: ArticleProps) => {
 
   return (
     <div className="article-preview" style={{ padding: '1.5rem 0.5rem' }}>
-      <div
-        className="article-meta-wrapper"
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-        }}
-      >
+      <div className="article-meta-wrapper">
         <ArticleMeta article={preview} showActions={false} />
         <div className="pull-xs-right">
           <button

--- a/lib/types/articleType.ts
+++ b/lib/types/articleType.ts
@@ -14,10 +14,6 @@ export type ArticleType = {
   tags?: string[];
 };
 
-export interface ArticleResponse {
-  article: ArticleType;
-}
-
 export interface ArticleListResponse {
   articles: ArticleType[];
   articlesCount: number;

--- a/lib/types/articleType.ts
+++ b/lib/types/articleType.ts
@@ -14,6 +14,10 @@ export type ArticleType = {
   tags?: string[];
 };
 
+export interface ArticleResponse {
+  article: ArticleType;
+}
+
 export interface ArticleListResponse {
   articles: ArticleType[];
   articlesCount: number;

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import Head from 'next/head';
+
+const Custom404 = () => {
+  return (
+    <>
+      <Head>
+        <title>404 - 페이지를 찾을 수 없습니다</title>
+        <meta
+          name="description"
+          content="요청하신 페이지가 존재하지 않거나 이동되었을 수 있습니다."
+        />
+      </Head>
+
+      <div className="error-page">
+        <div className="error-content">
+          <div className="error-emoji">🔍</div>
+          <h1 className="error-title">
+            <span className="error-code">404</span>
+            페이지를 찾을 수 없습니다
+          </h1>
+          <p className="error-message">
+            요청하신 페이지가 존재하지 않거나 이동되었을 수 있습니다.
+          </p>
+
+          <div className="error-actions">
+            <a href="/">홈으로 돌아가기</a>
+          </div>
+        </div>
+
+        <style jsx>{`
+          .error-page {
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+          }
+
+          .error-content {
+            text-align: center;
+          }
+
+          .error-emoji {
+            font-size: 64px;
+            margin-bottom: 24px;
+            animation: bounce 2s infinite;
+          }
+
+          @keyframes bounce {
+            0%,
+            20%,
+            50%,
+            80%,
+            100% {
+              transform: translateY(0);
+            }
+            40% {
+              transform: translateY(-10px);
+            }
+            60% {
+              transform: translateY(-5px);
+            }
+          }
+
+          .error-title {
+            font-size: 28px;
+            font-weight: 700;
+            color: #2d3748;
+            margin-bottom: 16px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 12px;
+            flex-wrap: wrap;
+          }
+
+          .error-code {
+            background: #fed7d7;
+            color: #c53030;
+            padding: 4px 12px;
+            border-radius: 8px;
+            font-size: 20px;
+            font-weight: 600;
+          }
+
+          .error-message {
+            font-size: 16px;
+            color: #718096;
+            line-height: 1.6;
+            margin-bottom: 32px;
+          }
+
+          .error-actions {
+            display: flex;
+            gap: 16px;
+            justify-content: center;
+            flex-wrap: wrap;
+          }
+
+          @media (max-width: 640px) {
+            .error-content {
+              padding: 32px 24px;
+            }
+
+            .error-title {
+              font-size: 24px;
+            }
+
+            .error-emoji {
+              font-size: 48px;
+            }
+
+            .error-actions {
+              flex-direction: column;
+            }
+          }
+        `}</style>
+      </div>
+    </>
+  );
+};
+
+export default Custom404;

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -10,13 +10,6 @@ interface ErrorProps {
 
 const ErrorPage = ({ statusCode }: ErrorProps) => {
   const getErrorMessage = () => {
-    if (statusCode === 404) {
-      return {
-        title: '페이지를 찾을 수 없습니다',
-        message: '요청하신 페이지가 존재하지 않거나 이동되었을 수 있습니다.',
-        emoji: '🔍',
-      };
-    }
 
     if (statusCode === 500) {
       return {

--- a/pages/article/[id]/[title].tsx
+++ b/pages/article/[id]/[title].tsx
@@ -1,7 +1,7 @@
 import ArticleMeta from '../../../features/article/ArticleMeta';
 import CommentList from '../../../features/comment/CommentList';
 import ArticleAPI from '../../../lib/api/article';
-import { ArticleType, ArticleResponse } from '../../../lib/types/articleType';
+import { ArticleType } from '../../../lib/types/articleType';
 
 function ArticleBanner({ article }: { article: ArticleType }) {
   return (
@@ -45,34 +45,46 @@ function CommentsSection() {
   );
 }
 
-function ArticlePage({ initialArticle }: { initialArticle: ArticleResponse }) {
+function ArticlePage({ article }: { article: ArticleType }) {
   return (
     <div className="article-page">
-      <ArticleBanner article={initialArticle.article} />
-
+      <ArticleBanner article={article} />
       <div className="container page">
-        <ArticleBody article={initialArticle.article} />
-
+        <ArticleBody article={article} />
         <hr />
-
         <CommentsSection />
       </div>
     </div>
   );
 }
 
-export async function getServerSideProps({ query }) {
+export async function getServerSideProps({ query, res }) {
   const { id } = query;
+
+  if (!id || isNaN(Number(id))) {
+    res.writeHead(302, { Location: '/404' });
+    res.end();
+    return { props: {} };
+  }
+
   try {
     const {
       data: { article },
     } = await ArticleAPI.get(id);
-    return { props: { initialArticle: { article } } };
-  } catch (error) {
-    console.error('Article fetch error:', error);
+    if (!article) {
+      res.writeHead(302, { Location: '/404' });
+      res.end();
+      return { props: {} };
+    }
     return {
-      notFound: true,
+      props: {
+        article: article,
+      },
     };
+  } catch (error) {
+    res.writeHead(302, { Location: '/404' });
+    res.end();
+    return { props: {} };
   }
 }
 

--- a/pages/article/[id]/[title].tsx
+++ b/pages/article/[id]/[title].tsx
@@ -60,22 +60,10 @@ function ArticlePage({ article }: { article: ArticleType }) {
 
 export async function getServerSideProps({ query, res }) {
   const { id } = query;
-
-  if (!id || isNaN(Number(id))) {
-    res.writeHead(302, { Location: '/404' });
-    res.end();
-    return { props: {} };
-  }
-
   try {
     const {
       data: { article },
     } = await ArticleAPI.get(id);
-    if (!article) {
-      res.writeHead(302, { Location: '/404' });
-      res.end();
-      return { props: {} };
-    }
     return {
       props: {
         article: article,

--- a/pages/profile/[pid].tsx
+++ b/pages/profile/[pid].tsx
@@ -78,28 +78,13 @@ function Profile({ profile }) {
 
 export async function getServerSideProps({ query, res }) {
   const { pid } = query;
-
-  if (!pid) {
-    res.writeHead(302, { Location: '/404' });
-    res.end();
-    return { props: {} };
-  }
-
   try {
-    const result = await UserAPI.get(String(pid));
-    if (
-      !result ||
-      !result.data ||
-      !result.data.profile
-    ) {
-      res.writeHead(302, { Location: '/404' });
-      res.end();
-      return { props: {} };
-    }
-
+    const {
+      data: { profile },
+    } = await UserAPI.get(String(pid));
     return {
       props: {
-        profile: result.data.profile,
+        profile: profile,
       },
     };
   } catch (error) {

--- a/pages/user/settings.tsx
+++ b/pages/user/settings.tsx
@@ -56,7 +56,7 @@ function Settings({ user }) {
   );
 }
 
-export async function getServerSideProps(context) {
+export async function getServerSideProps() {
   try {
     const user = await getCurrentUserWithProfile();
     return {


### PR DESCRIPTION
## #️⃣연관된 이슈
- #35 

## 📝작업 내용

1. `_error.tsx`에서 404 에러까지 처리하고 있었는데, 404 에러는 따로 404.tsx 페이지로 분리해서 에러 처리
- 이유
   - 404.tsx는 유저가 잘못된 경로로 접근했을 때 보여주는 안내 페이지
   - _error.tsx는 앱에서 실제로 문제가 발생한 경우 보여주는 에러 핸들러 

2. profile 페이지 데이터 페칭 방식 `getInitalProps` -> `getServerSideProps`로 변경
- 이유
   - 서버에서 에러를 처리하기 위해 
